### PR TITLE
Update plotting.py: imshow default interpolation method

### DIFF
--- a/beat/plotting.py
+++ b/beat/plotting.py
@@ -1391,7 +1391,7 @@ def scene_fits(problem, stage, plot_options):
                 map_displacement_grid(datavec, scene),
                 extent=im_extent, cmap=cmap,
                 vmin=vmin, vmax=vmax,
-                origin='lower'))
+                origin='lower', interpolation='nearest'))
 
             ax.set_xlim(llE, urE)
             ax.set_ylim(llN, urN)


### PR DESCRIPTION
Added 'nearest' as the default interpolation method in plotting scene_fits with matplotlib.pyplot.imshow

Matplotlib introduced a change in the default interpolation version: 'nearest' > 'antaliased' since ver. 3.3