### PR TITLE
Option to build EPcrust model with BEAT

### DIFF
--- a/beat/config.py
+++ b/beat/config.py
@@ -298,6 +298,14 @@ class NonlinearGFConfig(GFConfig):
         default=True,
         help='Flag, for replacing the crust from the earthmodel'
              'with crust from the crust2 model.')
+    use_epcrust = Bool.T(
+        default=True,
+        help='Flag, for replacing the crust from the earthmodel'
+             'with crust from the EPcrust model.')
+    epcrust_radius = Float.T(
+        default=50,
+        help='Get the average EPcrust profile in the defined radius around Reference location'
+             'radius is in km')
     replace_water = Bool.T(
         default=True,
         help='Flag, for replacing water layers in the crust2 model.')
@@ -1818,6 +1826,8 @@ def init_config(name, date=None, min_magnitude=6.0, main_path='./',
                 c.geodetic_config.gf_config.custom_velocity_model = \
                     load_model().extract(depth_max=100. * km)
                 c.geodetic_config.gf_config.use_crust2 = False
+                c.geodetic_config.gf_config.use_epcrust = False
+                c.geodetic_config.gf_config.epcrust_radius = 0
                 c.geodetic_config.gf_config.replace_water = False
         else:
             c.geodetic_config = None
@@ -1837,6 +1847,8 @@ def init_config(name, date=None, min_magnitude=6.0, main_path='./',
                 c.seismic_config.gf_config.custom_velocity_model = \
                     load_model().extract(depth_max=100. * km)
                 c.seismic_config.gf_config.use_crust2 = False
+                c.geodetic_config.gf_config.use_epcrust = False
+                c.geodetic_config.gf_config.epcrust_radius = 0
                 c.seismic_config.gf_config.replace_water = False
         else:
             c.seismic_config = None


### PR DESCRIPTION
1. To use this option:
add the following lines below the **"gf_config: !beat.SeismicGFConfig"** in your config.yaml file
use_crust2: false #need to deselect this option as you want to use epcrust
use_epcrust: true 
epcrust_radius: 20 # added this option to get the average EPcrust profile in the defined radius due to the high resolution of the model (0.5°x0.5°), use 0 if you want to get the EPcrust profile close to your reference location

In order to work pyrocko version needs to have the following:
modified cake.py to accept ep_crust and
ep_crust.py, EPcrust_0_5.txt, Ice_thickness_0_5.txt in the folder pyrocko/dataset


2. Also, changed the lines that define the extra config parameters for qseis to introduce the possibility to automatically adjust the GF window length in accordance to the station distance from the event.
[pyrocko.zip](https://github.com/hvasbath/beat/files/7145708/pyrocko.zip)
